### PR TITLE
feat: ArticleSummarizer（Claude APIによる記事要約機能）の実装

### DIFF
--- a/src/db/article_repository.py
+++ b/src/db/article_repository.py
@@ -70,6 +70,10 @@ class ArticleRepository:
             )
             return [dict(row) for row in cursor.fetchall()]
 
+    def update_summary(self, url: str, summary: str) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute("UPDATE articles SET summary = ? WHERE url = ?", (summary, url))
+
     def mark_as_summarized(self, url: str) -> None:
         with sqlite3.connect(self.db_path) as conn:
             conn.execute("UPDATE articles SET is_summarized = 1 WHERE url = ?", (url,))

--- a/src/summarizer/article_summarizer.py
+++ b/src/summarizer/article_summarizer.py
@@ -1,0 +1,39 @@
+import anthropic
+
+SYSTEM_PROMPT = (
+    "あなたはData・AI分野の専門ニュースライターです。"
+    "与えられた記事を日本語で簡潔に要約してください。"
+    "要約は3〜5文程度で、技術的なポイントと影響を中心にまとめてください。"
+    "読者はデータエンジニアやAIエンジニアを想定しています。"
+)
+
+DEFAULT_MODEL = "claude-sonnet-4-5-20250929"
+
+
+class ArticleSummarizer:
+    def __init__(self, api_key: str, model: str = DEFAULT_MODEL):
+        self.client = anthropic.Anthropic(api_key=api_key)
+        self.model = model
+
+    def summarize(self, title: str, content: str) -> str:
+        user_message = f"タイトル: {title}\n\n本文: {content}" if content else f"タイトル: {title}"
+        response = self.client.messages.create(
+            model=self.model,
+            max_tokens=1024,
+            system=SYSTEM_PROMPT,
+            messages=[{"role": "user", "content": user_message}],
+        )
+        return response.content[0].text
+
+    def summarize_articles(self, articles: list[dict]) -> list[dict]:
+        results = []
+        for article in articles:
+            try:
+                summary = self.summarize(
+                    title=article["title"],
+                    content=article.get("summary", ""),
+                )
+                results.append({"url": article["url"], "summary": summary})
+            except Exception as e:
+                results.append({"url": article["url"], "summary": None, "error": str(e)})
+        return results

--- a/tests/test_db/test_article_repository.py
+++ b/tests/test_db/test_article_repository.py
@@ -84,3 +84,14 @@ class TestArticleRepository:
         unsummarized = repo.get_unsummarized()
         assert len(unsummarized) == 1
         assert unsummarized[0]["url"] == "https://a.com/2"
+
+    def test_記事の要約を更新できる(self, repo):
+        article = Article("A1", "https://a.com/1", "元の要約", "Src1", "2026-01-01")
+        repo.save(article)
+        repo.update_summary("https://a.com/1", "AIによる新しい要約")
+        articles = repo.get_all()
+        assert articles[0]["summary"] == "AIによる新しい要約"
+
+    def test_存在しないURLの要約更新は何も起きない(self, repo):
+        repo.update_summary("https://nonexistent.com", "要約テキスト")
+        assert len(repo.get_all()) == 0

--- a/tests/test_summarizer/test_article_summarizer.py
+++ b/tests/test_summarizer/test_article_summarizer.py
@@ -1,0 +1,83 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.summarizer.article_summarizer import ArticleSummarizer
+
+
+@pytest.fixture
+def mock_client():
+    client = MagicMock()
+    mock_response = MagicMock()
+    mock_response.content = [MagicMock(text="これはAIによる要約です。")]
+    client.messages.create.return_value = mock_response
+    return client
+
+
+@pytest.fixture
+def summarizer(mock_client):
+    with patch("src.summarizer.article_summarizer.anthropic.Anthropic", return_value=mock_client):
+        return ArticleSummarizer(api_key="test-api-key")
+
+
+class TestArticleSummarizer:
+    def test_初期化時にモデル名がデフォルト設定される(self):
+        with patch("src.summarizer.article_summarizer.anthropic.Anthropic"):
+            s = ArticleSummarizer(api_key="test-key")
+            assert s.model == "claude-sonnet-4-5-20250929"
+
+    def test_初期化時にモデル名を指定できる(self):
+        with patch("src.summarizer.article_summarizer.anthropic.Anthropic"):
+            s = ArticleSummarizer(api_key="test-key", model="claude-haiku-4-5-20251001")
+            assert s.model == "claude-haiku-4-5-20251001"
+
+    def test_単一記事を要約できる(self, summarizer, mock_client):
+        result = summarizer.summarize(
+            title="新しいLLMが登場",
+            content="OpenAIが新しい大規模言語モデルを発表しました。",
+        )
+        assert result == "これはAIによる要約です。"
+        mock_client.messages.create.assert_called_once()
+        call_kwargs = mock_client.messages.create.call_args[1]
+        assert call_kwargs["model"] == "claude-sonnet-4-5-20250929"
+        assert call_kwargs["max_tokens"] == 1024
+
+    def test_要約プロンプトにタイトルと本文が含まれる(self, summarizer, mock_client):
+        summarizer.summarize(title="テストタイトル", content="テスト本文")
+        call_kwargs = mock_client.messages.create.call_args[1]
+        user_message = call_kwargs["messages"][0]["content"]
+        assert "テストタイトル" in user_message
+        assert "テスト本文" in user_message
+
+    def test_本文が空の場合タイトルのみで要約できる(self, summarizer, mock_client):
+        result = summarizer.summarize(title="タイトルだけの記事", content="")
+        assert result == "これはAIによる要約です。"
+        mock_client.messages.create.assert_called_once()
+
+    def test_複数記事を一括要約できる(self, summarizer, mock_client):
+        articles = [
+            {"url": "https://a.com/1", "title": "記事1", "summary": "概要1"},
+            {"url": "https://a.com/2", "title": "記事2", "summary": "概要2"},
+        ]
+        results = summarizer.summarize_articles(articles)
+        assert len(results) == 2
+        assert results[0]["url"] == "https://a.com/1"
+        assert results[0]["summary"] == "これはAIによる要約です。"
+        assert results[1]["url"] == "https://a.com/2"
+        assert mock_client.messages.create.call_count == 2
+
+    def test_API呼び出し失敗時はエラーを返す(self, summarizer, mock_client):
+        mock_client.messages.create.side_effect = Exception("API Error")
+        results = summarizer.summarize_articles(
+            [{"url": "https://a.com/1", "title": "記事1", "summary": "概要1"}]
+        )
+        assert len(results) == 1
+        assert results[0]["url"] == "https://a.com/1"
+        assert results[0]["summary"] is None
+        assert "API Error" in results[0]["error"]
+
+    def test_システムプロンプトが日本語要約を指示している(self, summarizer, mock_client):
+        summarizer.summarize(title="テスト", content="テスト内容")
+        call_kwargs = mock_client.messages.create.call_args[1]
+        assert "system" in call_kwargs
+        assert "日本語" in call_kwargs["system"]


### PR DESCRIPTION
- ArticleSummarizerクラスを追加（Claude APIで記事を日本語要約）
- 単一記事・複数記事の一括要約に対応
- API呼び出し失敗時のエラーハンドリングを実装
- ArticleRepositoryにupdate_summaryメソッドを追加
- テスト17件すべてパス

https://claude.ai/code/session_019WAHb5d2bTXZZ1aTkUVRAY